### PR TITLE
Fix react15 warning about unknown props

### DIFF
--- a/src/index.cjsx
+++ b/src/index.cjsx
@@ -28,13 +28,18 @@ module.exports = React.createClass
     unless @props.noFadeIn
       require '../css/fade-in.css'
 
+    props = Object.assign({}, @props)
+    delete props.spinnerName
+    delete props.noFadeIn
+    delete props.overrideSpinnerClassName
+
     switch @props.spinnerName
 
       when "three-bounce"
         require '../css/three-bounce.css'
         return (
           (
-            <div {... @props} className={"three-bounce " + classes}>
+            <div {... props} className={"three-bounce " + classes}>
               <div className="bounce1"></div>
               <div className="bounce2"></div>
               <div className="bounce3"></div>
@@ -46,7 +51,7 @@ module.exports = React.createClass
         require '../css/double-bounce.css'
         return (
           (
-            <div {... @props} className={"double-bounce " + classes}>
+            <div {... props} className={"double-bounce " + classes}>
               <div className="double-bounce1"></div>
               <div className="double-bounce2"></div>
             </div>
@@ -57,7 +62,7 @@ module.exports = React.createClass
         require '../css/rotating-plane.css'
         return (
           (
-            <div {... @props} className={classes}>
+            <div {... props} className={classes}>
               <div className={"rotating-plane"}/>
             </div>
           )
@@ -67,7 +72,7 @@ module.exports = React.createClass
         require '../css/wave.css'
         return (
           (
-            <div {... @props} className={"wave " + classes}>
+            <div {... props} className={"wave " + classes}>
               <div className="rect1"></div>
               <div className="rect2"></div>
               <div className="rect3"></div>
@@ -81,7 +86,7 @@ module.exports = React.createClass
         require '../css/wandering-cubes.css'
         return (
           (
-            <div {... @props} className={"wandering-cubes " + classes}>
+            <div {... props} className={"wandering-cubes " + classes}>
               <div className="cube1"></div>
               <div className="cube2"></div>
             </div>
@@ -92,7 +97,7 @@ module.exports = React.createClass
         require '../css/pulse.css'
         return (
           (
-            <div {... @props} className={classes}>
+            <div {... props} className={classes}>
               <div className="pulse" />
             </div>
           )
@@ -102,7 +107,7 @@ module.exports = React.createClass
         require '../css/chasing-dots.css'
         return (
           (
-            <div {... @props} className={classes}>
+            <div {... props} className={classes}>
               <div className="chasing-dots">
                 <div className="dot1"></div>
                 <div className="dot2"></div>
@@ -115,7 +120,7 @@ module.exports = React.createClass
         require '../css/circle.css'
         return (
           (
-            <div {... @props} className={"circle-wrapper " + classes}>
+            <div {... props} className={"circle-wrapper " + classes}>
               <div className="circle1 circle"></div>
               <div className="circle2 circle"></div>
               <div className="circle3 circle"></div>
@@ -136,7 +141,7 @@ module.exports = React.createClass
         require '../css/cube-grid.css'
         return (
           (
-            <div {... @props} className={"cube-grid " + classes}>
+            <div {... props} className={"cube-grid " + classes}>
               <div className="cube"></div>
               <div className="cube"></div>
               <div className="cube"></div>
@@ -154,7 +159,7 @@ module.exports = React.createClass
         require '../css/wordpress.css'
         return (
           (
-            <div {... @props} className={classes}>
+            <div {... props} className={classes}>
               <div className="wordpress">
                 <span className="inner-circle"></span>
               </div>


### PR DESCRIPTION
## Links
- [Upgrading to React 15.2.0 throws "unknown props" warning](https://github.com/KyleAMathews/react-spinkit/issues/35)
- [react-unknown-prop.md](https://gist.github.com/jimfb/d99e0678e9da715ccf6454961ef04d1b)

## Problem
"The unknown-prop warning will fire if you attempt to render a DOM element with a prop that is not recognized by React as a legal DOM attribute/property." In this case, since `@props` are passed as-is to the child `div` using `...`, the div ends up with invalid html properties.

## Solution
Coffeescript [doesn't seem to have support](https://github.com/jashkenas/coffeescript/issues/3894) for the succinct solution:

```javascript
const { layout, ...rest } = props;
return <div {...rest} />
```

So I used `Object.assign` for making a copy of props and then removing the unwanted keys.

## Test plan
I built the project by:

1. Running `npm install` 
2. Installing webpack globally
3. Installing React locally (perhaps consider including it in `peerDependencies`)
4. Running `make build`

And tested it in my project using `npm link`. It stopped showing the warning!