### PR TITLE
Switch to prop-types library per React v15.5 deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "classnames": "^2.2.3",
-    "object-assign": "^4.1.0"
+    "object-assign": "^4.1.0",
+    "prop-types": "^15.5.8"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'; // eslint-disable-line import/no-extraneous-dependencies
 import cx from 'classnames';
 import assign from 'object-assign';
@@ -156,10 +157,10 @@ class Spinner extends React.Component {
 }
 
 Spinner.propTypes = {
-  spinnerName: React.PropTypes.string.isRequired,
-  noFadeIn: React.PropTypes.bool,
-  overrideSpinnerClassName: React.PropTypes.string,
-  className: React.PropTypes.string,
+  spinnerName: PropTypes.string.isRequired,
+  noFadeIn: PropTypes.bool,
+  overrideSpinnerClassName: PropTypes.string,
+  className: PropTypes.string,
 };
 
 Spinner.defaultProps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1823,6 +1823,18 @@ fbjs@^0.8.1, fbjs@^0.8.4:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -3328,6 +3340,12 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.5.8:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
 
 prr@~0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Pretty simple update to avoid deprecation warnings for people on React v15.5 and prepare for React v16