### PR TITLE
Circle spinner - IE11 compatibility

### DIFF
--- a/css/circle.css
+++ b/css/circle.css
@@ -5,7 +5,7 @@
 }
 
 .sk-circle > div {
-  background-color: initial;
+  background-color: transparent;
   width: 100%;
   height: 100%;
   position: absolute;


### PR DESCRIPTION
Change background-color to transparent so the circle spinner is working in IE11